### PR TITLE
deprecation-alias 0.4.0 (tests) :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: a58d2e74491c7834e9d318788da60272fa2f81aeb814b4055a4ba90a0a41740f
+  url: https://github.com/domdfcoding/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: a8a9822921faa2b59927894a9347400c471ba7fe41ef173be4e556ce118d20eb
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 
@@ -25,18 +25,21 @@ requirements:
     - deprecation >=2.1.0
     - packaging >=20.4
   run_constrained:
-    python >=3.6.1
+    - python >=3.6.1
 
-# We can`t enable pytest because conftest uses the coincidence package, which is unavailable on the main channel.
-# The policy states that packages are not specifically built for testing.
 test:
+  source_files:
+    - tests
   imports:
     - deprecation_alias
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
   requires:
     - pip
+    - pytest >=6.0.0
+    - coincidence >=0.2.0
 
 about:
   home: https://github.com/domdfcoding/deprecation-alias
@@ -45,7 +48,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   description: A wrapper around 'deprecation' providing support for deprecated aliases.
-  doc_url: https://github.com/domdfcoding/deprecation-alias/blob/v0.4.0/README.rst
+  doc_url: https://github.com/domdfcoding/deprecation-alias/blob/master/README.rst
   dev_url: https://github.com/domdfcoding/deprecation-alias
 
 extra:


### PR DESCRIPTION
deprecation-alias 0.4.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8201]
- dev_url:        https://github.com/domdfcoding/deprecation-alias/tree/v0.4.0
- conda_forge:    https://github.com/conda-forge/deprecation-alias-feedstock
- pypi:           https://pypi.org/project/deprecation-alias/0.4.0
- pypi inspector: https://inspector.pypi.io/project/deprecation-alias/0.4.0

### Explanation of changes:

- new version number


[PKG-8201]: https://anaconda.atlassian.net/browse/PKG-8201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ